### PR TITLE
add joiner/joinerfunc and joiner tests

### DIFF
--- a/joiner.go
+++ b/joiner.go
@@ -28,3 +28,16 @@ func NewJoiner(jointer string) JoinerFunc {
 		return fmt.Sprintf("%s%s%s", part1, jointer, part2)
 	}
 }
+
+// NewJoinerChain takes a Joiner and a chain of Processors and joins the
+// Processors onto the output of the Joiner.
+func NewJoinerChain(joiner Joiner, processors ...Processor) JoinerFunc {
+	return func(part1, part2 string) (result string) {
+		result = joiner.Join(part1, part2)
+		for _, p := range processors {
+			result = p.Process(result)
+		}
+
+		return
+	}
+}

--- a/joiner.go
+++ b/joiner.go
@@ -4,9 +4,27 @@
 
 package unis
 
+import "fmt"
+
 // Joiner should be implemented by all string joiners.
 type Joiner interface {
 	// Join takes two pieces of strings
 	// and returns a result of them, as one.
 	Join(part1 string, part2 string) string
+}
+
+// JoinerFunc is the alias type of Joiner, it implements the Joiner also.
+type JoinerFunc func(part1, part2 string) string
+
+// Join takes two pieces of strings and returns a result of them, as one.
+func (j JoinerFunc) Join(part1, part2 string) string {
+	return j(part1, part2)
+}
+
+// NewJoiner returns a new joiner which joins
+// two strings into one string, based on a "jointer".
+func NewJoiner(jointer string) JoinerFunc {
+	return func(part1, part2 string) string {
+		return fmt.Sprintf("%s%s%s", part1, jointer, part2)
+	}
 }

--- a/joiner_test.go
+++ b/joiner_test.go
@@ -1,6 +1,8 @@
 package unis
 
 import (
+	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -29,6 +31,39 @@ func TestJoinerFunc_Join(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := tt.j.Join(tt.args.part1, tt.args.part2); got != tt.want {
 				t.Errorf("JoinerFunc.Join() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewJoinerChain(t *testing.T) {
+	type args struct {
+		joiner     Joiner
+		processors []Processor
+		part1      string
+		part2      string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			"joinerchain1",
+			args{
+				NewJoiner("/"),
+				[]Processor{ProcessorFunc(strings.ToLower), NewPrepender("http://")},
+				"the",
+				"path",
+			},
+			"http://the/path",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			joinerchain := NewJoinerChain(tt.args.joiner, tt.args.processors...)
+			if got := joinerchain.Join(tt.args.part1, tt.args.part2); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NewJoinerChain().Join(%s, %s) = %v, want %v", tt.args.part1, tt.args.part2, got, tt.want)
 			}
 		})
 	}

--- a/joiner_test.go
+++ b/joiner_test.go
@@ -1,0 +1,35 @@
+package unis
+
+import (
+	"testing"
+)
+
+func TestJoinerFunc_Join(t *testing.T) {
+	type args struct {
+		part1 string
+		part2 string
+	}
+	tests := []struct {
+		name string
+		j    JoinerFunc
+		args args
+		want string
+	}{
+		{
+			"join1",
+			NewJoiner("/"),
+			args{
+				"file",
+				"path",
+			},
+			"file/path",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.j.Join(tt.args.part1, tt.args.part2); got != tt.want {
+				t.Errorf("JoinerFunc.Join() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
I essentially copied the work already done on the `Divider` interface but changed it to `Joiner`. Not sure if this is the way you wanted to go but it seemed odd not to have it. 

Cheers for this package! It addresses a problem I have been facing for a while now, which is the naming and standardizing of string formatting functions. 👍 